### PR TITLE
Check md5sums on existing files, skipping download if they match.

### DIFF
--- a/installer/installermodule/downloader.py
+++ b/installer/installermodule/downloader.py
@@ -116,6 +116,7 @@ class Downloader():
                         with open(fulldestination + ".md5sum", 'r') as f:
                             remotemd5sum = f.read().split(" ")[0].strip()
                             print("Remote file md5sum is " + remotemd5sum)
+                        os.remove(fulldestination + ".md5sum")
                         if remotemd5sum == sum:
                             print("Skipping URL " + myurl + " as existing file matches.")
                             threadQueue.task_done()


### PR DESCRIPTION

 * Have a remote list of MD5sums on the server.
 * Download these MD5sums before downloading the file.
 * MD5sum the existing file. If it matches, skip this file to save time.