### PR TITLE
Fix #84 by changing how we check mirrors.

### DIFF
--- a/installer/Installer.py
+++ b/installer/Installer.py
@@ -56,7 +56,10 @@ def mirrorCheck():
         print("DEBUG: Checking",m)
         errorstr = ""
         try: # Check to make sure mirror is reachable before adding it to our list.
-            retcode = urllib.request.urlopen(m,timeout=4).getcode() # 4 seconds may be too fast, but I'm trying to avoid needing to thread this call.
+            if (("cloudfront" in m) or ("s3" in m)): # AWS works a little differently, so we need to grab an actual file, not a listing.
+                retcode = urllib.request.urlopen(m + "contrib/twue.ips",timeout=4).getcode()
+            else:
+                retcode = urllib.request.urlopen(m,timeout=4).getcode() # 4 seconds may be too fast, but I'm trying to avoid needing to thread this call.
         except urllib.error.URLError as e:
             retcode = -1
             errorstr = e.reason


### PR DESCRIPTION
 * In the case of Amazon S3, there's no "folders" so there's no such real thing as a directory listing. As such, our mirror checker script was returning errors all the time. We fix this by asking for a specific file, instead of asking for a directory listing.